### PR TITLE
Make projects clickable

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@
           append(ul, li);
         });
       }
+    })
+    .catch(function(error) {
+      console.error(error);
     });
 })();
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@
         let ul = createNode("ul");
         append(section, ul);
         projects[project].map(function(data) {
-          let imageContainer = createNode("div");
+          let imageContainer = createNode("a");
+          imageContainer.href = "https://scratch.mit.edu/projects/" + data.id + "/";
           imageContainer.className = "imageContainer";
           let li = createNode("li"),
             img = createNode("img"),

--- a/style.css
+++ b/style.css
@@ -79,6 +79,8 @@ div.desc {
     border: 1px solid #ccc;
     float: left;
     width: 250px;
+    color: black;
+    text-decoration: none;
 }
 
 .imageContainer:hover {

--- a/style.css
+++ b/style.css
@@ -74,18 +74,18 @@ div.desc {
     padding: 15px;
 }
 
-div.imageContainer {
+.imageContainer {
     margin: 5px;
     border: 1px solid #ccc;
     float: left;
     width: 250px;
 }
 
-div.imageContainer:hover {
+.imageContainer:hover {
     border: 1px solid #777;
 }
 
-div.imageContainer img {
+.imageContainer img {
     width: 100%;
     height: auto;
 }


### PR DESCRIPTION
This pull request makes it so that, when you click a project thumbnail, that Scratch project page opens up.

There's no visual difference, except that the mouse becomes a pointer cursor when you put it over a project.

I made this work by changing the `imageContainer` to an `<a>` instead of a `<div>`, and I set the appropriate `href` on `imageContainer`. I had to change `style.css` so that the styles would still work.